### PR TITLE
allow paths and definitions init

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -133,8 +133,8 @@ module.exports = function(options) {
   var swaggerObject = [];
   swaggerObject = options.swaggerDefinition;
   swaggerObject.swagger = '2.0';
-  swaggerObject.paths = {};
-  swaggerObject.definitions = {};
+  swaggerObject.paths = options.swaggerDefinition.paths || {};
+  swaggerObject.definitions = options.swaggerDefinition.definitions || {};
 
   // Parse the documentation in the APIs array.
   for (var i = 0; i < options.apis.length; i = i + 1) {


### PR DESCRIPTION
Allow to prepare and load external paths and definitions
like this
```
        const swaggerSpec = swaggerJSDoc({
            swaggerDefinition: {
                info: {
                    title: 'MaboxRh Admin', // Title (required)
                    version: '1.0.0', // Version (required)
                },
                definitions: {
                    in_login : require("config/schemajson/in.login.schema.json"),
                    in_logout : require("config/schemajson/out.login.schema.json"),
                }
            },
            apis: ["rest.js"]
        });

```